### PR TITLE
nix/configuration: disable automatic GC

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -27,7 +27,6 @@
     "systemd.journald.forward_to_console=1"
   ];
 
-  nix.gc.automatic = true;
   nix.settings.max-jobs = 8;
 
   # Configure networking


### PR DESCRIPTION
For some reason the sd-image doesn't register its own system as a GC root, so this quickly starts to garbage-collect the currently booted system, which is not what we want.

Disable the GC.