### PR TITLE
nix: machine -> machine-generic, add machine-cm3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ Whenever there's a change in the crate dependencies, run
 A NixOS machine config is provided in `nix/configuration.nix`.
 It describes running fossbeamer in a wayland compositor, cage.
 
+We have two flavours, `machine-generic` and `machine-cm3`, as the CM3 variant
+needs to have its own bootloader.
+
 The system closure can be built with:
-`nix-build nix -A machine.toplevel`
+`nix-build nix -A machine-generic.toplevel`
 
 An SD-card image can be built with:
-`nix-build nix -A machine.sdImage`
+`nix-build nix -A machine-generic.sdImage`
 
 If you invoke the build from `x86_64-linux`, it'll cross-compile the sdcard
 image. If you build on an `aarch64-linux` box, it'll natively compile. Both

--- a/nix/configuration-cm3.nix
+++ b/nix/configuration-cm3.nix
@@ -1,0 +1,31 @@
+# Machine config, specifically for raspberry cm3
+{ config
+, modulesPath
+, pkgs
+, lib
+, ...
+}:
+
+let
+  ubootRaspberryPiGeneric = pkgs.buildUBoot {
+    defconfig = "rpi_arm64_defconfig";
+    extraMeta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
+  };
+
+in
+{
+  imports = [ ./configuration.nix ];
+
+  sdImage.populateFirmwareCommands = ''
+    rm firmware/u-boot-rpi3.bin
+    # Overwrite firmware/u-boot-rpi3.bin with the generic one
+    cp ${ubootRaspberryPiGeneric}/u-boot.bin firmware/u-boot-rpi3.bin    
+    # Add the .dtb for our board
+    cp ${pkgs.raspberrypifw}/share/raspberrypi/boot/bcm2710-rpi-cm3.dtb firmware/
+  '';
+
+  # u-boot doesn't know the proper device tree name, so cannot pick from FTDIR
+  # on its own.
+  hardware.deviceTree.name = "broadcom/bcm2837-rpi-cm3-io3.dtb";
+}

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -27,6 +27,11 @@
     "systemd.journald.forward_to_console=1"
   ];
 
+  # Switch to systemd-initrd, which is the future (tm).
+  # Also it has proven to be a bit more permissive with some boards where the
+  # sdcard takes ages to spin up.
+  boot.initrd.systemd.enable = true;
+
   nix.settings.max-jobs = 8;
 
   # Configure networking

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -32,7 +32,8 @@ let
     overlays = [ (import ./overlay.nix) ];
   };
 
-  machine = (pkgsAArch64.nixos ./configuration.nix);
+  machine-generic = (pkgsAArch64.nixos ./configuration.nix);
+  machine-cm3 = (pkgsAArch64.nixos ./configuration-cm3.nix);
 
 in
 rec {
@@ -49,7 +50,7 @@ rec {
     '';
   };
 
-  inherit machine;
+  inherit machine-generic machine-cm3;
 
   env = pkgs.buildEnv {
     name = "dev-env";


### PR DESCRIPTION
Add a custom target for the CM3 image, which requires a custom bootloader, and a hardcoded DTB name.