### PR TITLE
nix: add kmsprint

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -71,6 +71,7 @@
 
   environment.systemPackages = [
     pkgs.htop
+    pkgs.kmsxx # kmsprint
   ];
 
   users.users."root".initialPassword = "";


### PR DESCRIPTION
This is a bit nicer to determine what's connected.