### PR TITLE
nix/default.nix: call pkgsAArch64 with passed in `system` as localSystem

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -27,7 +27,7 @@ let
   ++ pango.buildInputs;
 
   pkgsAArch64 = import nixpkgs {
-    localSystem = builtins.currentSystem;
+    localSystem = system;
     crossSystem = "aarch64-linux";
     overlays = [ (import ./overlay.nix) ];
   };


### PR DESCRIPTION
This allows forcing the native build by passing in --argstr system …