### PR TITLE
nix/configuration: don't draw client decorations when possible

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -72,6 +72,9 @@
     environment.GDK_BACKEND = "x11";
     user = "kiosk";
     program = "${pkgs.fossbeamer}/bin/fossbeamer --default-config=${../default-config.json} https://example.com";
+    extraArguments = [
+      "-d" # don't draw client decorations when possible
+    ];
   };
 
   environment.systemPackages = [


### PR DESCRIPTION
This gets rid of the titlebar.