### PR TITLE
nix: set GST_PLUGIN_SYSTEM_PATH_1_0, LIBGL_DEBUG, RUST_LOG

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -71,7 +71,19 @@
     enable = true;
     user = "kiosk";
     program = "${pkgs.fossbeamer}/bin/fossbeamer --default-config=${../default-config.json} https://example.com";
-    environment.GIO_MODULE_DIR = "${pkgs.glib-networking}/lib/gio/modules/";
+    environment = {
+      GST_PLUGIN_SYSTEM_PATH_1_0 = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (with pkgs.gst_all_1;[
+        gstreamer
+        gst-plugins-base
+        gst-plugins-good
+        gst-plugins-bad
+        # gst-plugins-ugly
+        gst-libav
+      ]);
+      GIO_MODULE_DIR = "${pkgs.glib-networking}/lib/gio/modules/";
+      LIBGL_DEBUG = "verbose";
+      RUST_LOG = "debug";
+    };
     extraArguments = [
       "-d" # don't draw client decorations when possible
     ];


### PR DESCRIPTION
Webkit is mad if it cannot find gstreamer and seems to get stuck
otherwise.

LIBGL_DEBUG helps to debug GL stuff, and RUST_LOG our rust code.

~Depends on https://github.com/wipbar/fossbeamer/pull/19~