### PR TITLE
Fix rotation

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -70,7 +70,10 @@
   services.cage = {
     enable = true;
     user = "kiosk";
-    program = "${pkgs.fossbeamer}/bin/fossbeamer --default-config=${../default-config.json} https://example.com";
+    program = pkgs.writers.writeBash "run-cage-program" ''
+      ${pkgs.wlr-randr}/bin/wlr-randr --output HDMI-A-1 --transform 180
+      ${pkgs.fossbeamer}/bin/fossbeamer --default-config=${../default-config.json} https://wip.bar
+    '';
     environment = {
       GST_PLUGIN_SYSTEM_PATH_1_0 = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (with pkgs.gst_all_1;[
         gstreamer

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -3,12 +3,12 @@
         "branch": "nixos-unstable",
         "description": "Nix Packages collection",
         "homepage": null,
-        "owner": "NixOS",
+        "owner": "flokli",
         "repo": "nixpkgs",
-        "rev": "9e3825de8dbe84ae96c09000bc73ea1b82e7529b",
-        "sha256": "0jqhxwmqa5mriwmp41wjsi3c6srp9njk9qrv531d7f1dyzz0hnwh",
+        "rev": "d7c6aaa12742fc4b7b7151885c24b96a90159baf",
+        "sha256": "1847wrkm765fj92jjs8b4vabqj34rnxzkxp3hi9l5iyl4ycs7qar",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/9e3825de8dbe84ae96c09000bc73ea1b82e7529b.tar.gz",
+        "url": "https://github.com/flokli/nixpkgs/archive/d7c6aaa12742fc4b7b7151885c24b96a90159baf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
commit 0edd702c3a530c514075b8d9e7b870f41a01de1d
Author: Florian Klink <flokli@flokli.de>
Date:   Wed Jul 17 13:00:34 2024 +0200

    nix/configuration: rotate output by 180
    
    These displays are all mounted upside-down, for now just hardcode this.
    
    The proper fix would be to control these with
    https://wayland.app/protocols/wlr-output-management-unstable-v1
    and decide where to put it.

commit cfabf76584e9468251535319ba393f70b5b7889e
Author: Florian Klink <flokli@flokli.de>
Date:   Wed Jul 17 12:33:13 2024 +0200

    nix: bump nixpkgs, fix wlr-randr cross
    
    Contains https://github.com/NixOS/nixpkgs/pull/327863