### PR TITLE
nix: Disable docs to reduce closure size

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -98,6 +98,8 @@
     pkgs.i2c-tools
   ];
 
+  documentation.enable = false; # Reduces closure size and build time.
+
   users.users."root".initialPassword = "";
   system.stateVersion = "24.05";
 }


### PR DESCRIPTION
Before:
```
/nix/store/a4mkhxjb0cdds7d64cbgflqkdw9kr1kg-nixos-system-fossbeamer-24.11pre-git    222424    3405283432
```
After: 
```
/nix/store/k5czgnfjjvy4r0g9njl19sgpa90hvid9-nixos-system-fossbeamer-24.11pre-git    222424    3310507816
```