### PR TITLE
nix: set GST_PLUGIN_SYSTEM_PATH_1_0 and GIO_MODULE_DIR in shell

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -80,7 +80,6 @@
         gst-plugins-base
         gst-plugins-good
         gst-plugins-bad
-        # gst-plugins-ugly
         gst-libav
       ]);
       GIO_MODULE_DIR = "${pkgs.glib-networking}/lib/gio/modules/";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -47,6 +47,14 @@ rec {
     text = ''
       export NIX_PATH=nixpkgs=${toString pkgs.path}
       export PKG_CONFIG_PATH=${pkgs.lib.makeSearchPathOutput "dev" "lib/pkgconfig" rust_sys_dep_libs}
+      export GST_PLUGIN_SYSTEM_PATH_1_0=${pkgs.lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (with pkgs.gst_all_1;[
+        gstreamer
+        gst-plugins-base
+        gst-plugins-good
+        gst-plugins-bad
+        gst-libav
+      ])}
+      export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules/"
     '';
   };
 


### PR DESCRIPTION
This fixes `cargo run` on NixOS.

Also, remove the commented-out gst-plugins-ugly from the list, we apparently don't need it.

Followup on https://github.com/wipbar/fossbeamer/pull/22#discussion_r1680133049.