### PR TITLE
src/lib.rs: demote other events to debug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub fn spawn_browser(url: String, command_receiver: Option<Receiver<Command>>) -
                 };
             }
             _ => {
-                warn!(?event, "got other event")
+                debug!(?event, "got other event")
             }
         }
     })


### PR DESCRIPTION
These occur a lot.