### PR TITLE
nix: don't prevent cage restarts on config changes

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -90,6 +90,7 @@
       "-d" # don't draw client decorations when possible
     ];
   };
+  systemd.services."cage-tty1".restartIfChanged = lib.mkForce true;
 
   environment.systemPackages = [
     pkgs.htop


### PR DESCRIPTION
On NixOS, we normally want to prevent GUI processes from being restarted during a configuration switch, but not for this display setup.