### PR TITLE
nix/fossbeamer: use wrapGAppsHook instead of manual wrapper in cage

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -28,6 +28,17 @@ self: pkgs: rec {
       pkgs.defaultCrateOverrides // {
         fossbeamer = prev: {
           src = filterRustCrateSrc { root = prev.src.origSrc; };
+
+          nativeBuildInputs = [ pkgs.wrapGAppsHook ];
+          buildInputs = with pkgs; [
+            glib-networking
+          ] ++ (with gst_all_1; [
+            gstreamer
+            gst-plugins-base
+            gst-plugins-good
+            gst-plugins-bad
+            gst-libav
+          ]);
         };
       };
   };

--- a/nix/profiles/kiosk.nix
+++ b/nix/profiles/kiosk.nix
@@ -15,14 +15,6 @@
       ${pkgs.fossbeamer}/bin/fossbeamer --default-config=${../../default-config.json} https://wip.bar
     '';
     environment = {
-      GST_PLUGIN_SYSTEM_PATH_1_0 = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (with pkgs.gst_all_1;[
-        gstreamer
-        gst-plugins-base
-        gst-plugins-good
-        gst-plugins-bad
-        gst-libav
-      ]);
-      GIO_MODULE_DIR = "${pkgs.glib-networking}/lib/gio/modules/";
       LIBGL_DEBUG = "verbose";
       RUST_LOG = "debug";
     };


### PR DESCRIPTION
This fixes font sizes.
