### PR TITLE
nix/profiles/kiosk: remove unnecessary dconf

### DIFF
--- a/nix/profiles/kiosk.nix
+++ b/nix/profiles/kiosk.nix
@@ -3,7 +3,6 @@
   users.users.kiosk = {
     isNormalUser = true;
     uid = 1000;
-    packages = [ pkgs.dconf ];
   };
 
   # And configure cage to show fossbeamer on it.


### PR DESCRIPTION
This was a leftover from debugging the font size issue, it's not needed.